### PR TITLE
Don't track page views in Mixpanel by default.

### DIFF
--- a/lib/angulartics-mixpanel.js
+++ b/lib/angulartics-mixpanel.js
@@ -46,12 +46,16 @@ angular.module('angulartics.mixpanel', ['angulartics'])
 
   angulartics.waitForVendorApi('mixpanel', 500, '__loaded', function (mixpanel) {
     $analyticsProvider.registerPageTrack(function (path, callback) {
-      mixpanel.track( "Page Viewed", { "page": path }, callback );
+      callback = callback || function(){};
+      // tracking page views is not considered a best practice with mixpanel, so let's not do it.
+      // see https://mixpanel.com/help/questions/articles/why-measure-events-vs-page-views
+      //mixpanel.track( "Page Viewed", { "page": path }, callback );
     });
   });
 
   angulartics.waitForVendorApi('mixpanel', 500, '__loaded', function (mixpanel) {
     $analyticsProvider.registerEventTrack(function (action, properties, callback) {
+      callback = callback || function(){}
       mixpanel.track(action, properties, callback);
     });
   });


### PR DESCRIPTION
If you want to track page views, send a regular event with a 'page viewed' name as suggested by the documentation.
